### PR TITLE
Add recording capabilities

### DIFF
--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,2 @@
-connection.project.dir=
+connection.project.dir=app
 eclipse.preferences.version=1

--- a/app/.classpath
+++ b/app/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/app/.settings/org.eclipse.buildship.core.prefs
+++ b/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,2 @@
-connection.project.dir=..
+connection.project.dir=
 eclipse.preferences.version=1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.uwblueprint.dancefest">
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/uwblueprint/dancefest/CritiqueFormActivity.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/CritiqueFormActivity.kt
@@ -76,16 +76,13 @@ class CritiqueFormActivity : AppCompatActivity() {
         }
 
         artisticScoreInput.setText(
-            if (adjudication != null)
-                adjudication!!.artisticMark.toString() else EMPTY_STRING
+            adjudication?.artisticMark?.toString() ?: EMPTY_STRING
         )
         technicalScoreInput.setText(
-            if (adjudication != null)
-                adjudication!!.technicalMark.toString() else EMPTY_STRING
+            adjudication?.technicalMark?.toString() ?: EMPTY_STRING
         )
         notesInput.setText(
-            if (adjudication != null)
-                adjudication!!.notes else EMPTY_STRING
+            adjudication?.notes ?: EMPTY_STRING
         )
 
         populateInfoCard()
@@ -133,7 +130,7 @@ class CritiqueFormActivity : AppCompatActivity() {
                     }
                 }
             } else {
-                firestore.updateData(ADJpath, adjudication!!.adjudicationId, data)
+                firestore.updateData(ADJpath, adjudication!!.adjudicationId, data, true)
             }
 
             val intent = Intent(this, SavedCritiqueActivity::class.java)
@@ -143,7 +140,7 @@ class CritiqueFormActivity : AppCompatActivity() {
         ActivityCompat.requestPermissions(this, permissions, REQUEST_RECORDING_PERMISSION)
 
         // Each device only has one adjudication per performance so this is unique
-        // for the context of saving locally
+        // for the context of saving locally.
         localFileName = performance.performanceId
         if (adjudication != null) {
             firebasePath = adjudication!!.adjudicationId
@@ -283,11 +280,13 @@ class CritiqueFormActivity : AppCompatActivity() {
         } else {
             false
         }
-        if (!permissionToRecord) finish()
+        if (!permissionToRecord) {
+            finish()
+        }
     }
 
     private fun startRecording(fileName: String) {
-        // If external storage isn't available recording is impossible
+        // If external storage isn't available, recording is impossible
         if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED) {
             finish()
         }
@@ -358,6 +357,7 @@ class CritiqueFormActivity : AppCompatActivity() {
             mediaPlayer.setDataSource(mediaStream.fd)
             mediaPlayer.prepare()
             val length = mediaPlayer.duration
+            mediaPlayer.reset()
             mediaPlayer.release()
             mediaStream.close()
             showAudioModal(displayName, getDisplayTime(length))
@@ -375,6 +375,7 @@ class CritiqueFormActivity : AppCompatActivity() {
             mediaPlayer.setDataSource(mediaStream.fd)
             mediaPlayer.prepare()
             val length = mediaPlayer.duration
+            mediaPlayer.reset()
             mediaPlayer.release()
             mediaStream.close()
             return length

--- a/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
@@ -166,6 +166,7 @@ class PerformanceActivity : AppCompatActivity() {
                         completePerformances.add(newPerformance)
                         val adjDocData = it.documents[0].data
                         val artisticMark = adjDocData?.get(adjKeys.ARG_ARTISTIC_MARK)
+                        val audioLength = adjDocData?.get(adjKeys.ARG_AUDIO_LENGTH)
                         val audioURL = adjDocData?.get(adjKeys.ARG_AUDIO_URL)
                         val choreoAward = adjDocData?.get(adjKeys.ARG_CHOREO_AWARD)
                         val cumulativeMark = adjDocData?.get(adjKeys.ARG_CUMULATIVE_MARK)
@@ -177,6 +178,7 @@ class PerformanceActivity : AppCompatActivity() {
                         adjudications[performanceDoc.id] = Adjudication(
                             adjudicationId = it.documents[0].id,
                             artisticMark = FirestoreUtils.getVal(artisticMark, -1),
+                            audioLength = FirestoreUtils.getVal(audioLength, -1),
                             audioURL = FirestoreUtils.getVal(audioURL, DEFAULT),
                             choreoAward = FirestoreUtils.getVal(choreoAward, false),
                             cumulativeMark = FirestoreUtils.getVal(cumulativeMark, -1),

--- a/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
@@ -13,7 +13,7 @@ class FirestoreUtils {
         Takes a nullable object and default value as parameters, checks if the object is of type T,
         and if it is, returns the object casted as type T. Otherwise returns the default value.
         */
-        inline fun <reified T> getVal(value: Any?, default: T) : T =
+        inline fun <reified T> getVal(value: Any?, default: T): T =
             if (value is T) value else default
     }
 
@@ -50,11 +50,16 @@ class FirestoreUtils {
     fun updateData(
         collectionName: String,
         docName: String,
-        data: HashMap<String, Any?>
+        data: HashMap<String, Any?>,
+        merge: Boolean = false
     ) {
-        db.collection(collectionName).document(docName)
-            .set(data)
-            .addOnSuccessListener { Log.d(TAG, "DocumentSnapshot successfully written!") }
+        var docRef = db.collection(collectionName).document(docName)
+        var setTask = if (merge) {
+            docRef.set(data, SetOptions.merge())
+        } else {
+            docRef.set(data)
+        }
+        setTask.addOnSuccessListener { Log.d(TAG, "DocumentSnapshot successfully written!") }
             .addOnFailureListener { e -> Log.e(TAG, "Error writing document", e) }
     }
 }

--- a/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
@@ -51,7 +51,8 @@ class FirestoreUtils {
         collectionName: String,
         docName: String,
         data: HashMap<String, Any?>,
-        merge: Boolean = false
+        merge: Boolean = false,
+        callback: (() -> Unit)? = null
     ) {
         var docRef = db.collection(collectionName).document(docName)
         var setTask = if (merge) {
@@ -59,7 +60,12 @@ class FirestoreUtils {
         } else {
             docRef.set(data)
         }
-        setTask.addOnSuccessListener { Log.d(TAG, "DocumentSnapshot successfully written!") }
+        setTask.addOnSuccessListener {
+            Log.d(TAG, "DocumentSnapshot successfully written!")
+            if (callback != null) {
+                callback()
+            }
+        }
             .addOnFailureListener { e -> Log.e(TAG, "Error writing document", e) }
     }
 }

--- a/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/firebase/FirestoreUtils.kt
@@ -26,12 +26,16 @@ class FirestoreUtils {
 
     fun addData(
         collectionName: String,
-        data: HashMap<String, Any?>
+        data: HashMap<String, Any?>,
+        idCallback: ((String) -> Unit)? = null
     ) {
         db.collection(collectionName)
             .add(data)
             .addOnSuccessListener { documentReference ->
                 Log.d(TAG, "DocumentSnapshot written with ID: " + documentReference.id)
+                if (idCallback != null) {
+                    idCallback(documentReference.id)
+                }
             }
             .addOnFailureListener { e -> Log.e(TAG, "Error adding document", e) }
     }

--- a/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
@@ -5,6 +5,7 @@ import java.io.Serializable
 data class AdjudicationKeys(
     val ARG_ARTISTIC_MARK: String = "artisticMark",
     val ARG_AUDIO_URL: String = "audioURL",
+    val ARG_AUDIO_LENGTH: String = "audioLength",
     val ARG_CHOREO_AWARD: String = "choreoAward",
     val ARG_CUMULATIVE_MARK: String = "cumulativeMark",
     val ARG_JUDGE_NAME: String = "judgeName",

--- a/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
@@ -16,7 +16,7 @@ data class AdjudicationKeys(
 data class Adjudication(
     val adjudicationId: String,
     val artisticMark: Long = -1,
-    val audioURL: String,
+    val audioURL: String? = null,
     val choreoAward: Boolean,
     val cumulativeMark: Long = -1,
     val judgeName: String,

--- a/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/models/Adjudication.kt
@@ -16,13 +16,14 @@ data class AdjudicationKeys(
 data class Adjudication(
     val adjudicationId: String,
     val artisticMark: Long = -1,
-    val audioURL: String? = null,
     val choreoAward: Boolean,
     val cumulativeMark: Long = -1,
     val judgeName: String,
     val notes: String,
     val specialAward: Boolean,
-    val technicalMark: Long = -1
+    val technicalMark: Long = -1,
+    val audioURL: String? = null,
+    val audioLength: Int? = null
 ) : Serializable {
     companion object {
         val adjKeys = AdjudicationKeys()

--- a/app/src/main/res/drawable/ic_baseline_stop_24px.xml
+++ b/app/src/main/res/drawable/ic_baseline_stop_24px.xml
@@ -1,0 +1,4 @@
+<vector android:height="42dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="42dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_critique_form.xml
+++ b/app/src/main/res/layout/activity_critique_form.xml
@@ -506,10 +506,23 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="40dp"
+        android:fontFamily="@font/raleway_semibold"
         android:text="Audio File"
         android:textColor="#99ffffff"
         app:layout_constraintStart_toStartOf="@+id/notesCard"
-        app:layout_constraintTop_toBottomOf="@+id/notesCard" />
+        app:layout_constraintTop_toBottomOf="@+id/notesCard"/>
+
+    <TextView
+        android:id="@+id/audio_instructions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:fontFamily="@font/raleway_semibold"
+        android:text="@string/audio_instruction"
+        android:textColor="#61ffffff"
+        app:layout_constraintStart_toStartOf="@+id/notesCard"
+        app:layout_constraintTop_toBottomOf="@id/audioFileLabel"/>
 
     <android.support.v7.widget.CardView
         android:id="@+id/audioCard"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="colorPrimaryDark">#de2706</color>
     <color name="colorAccent">#111111</color>
     <color name="recordGreen">#319830</color>
+    <color name="recordStop">#de2706</color>
     <color name ="white">#FFFFFF</color>
     <color name="navTitles">#979797</color>
     <color name="mainCategoryTitle">#c4c4c4</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,9 +17,9 @@
     <string name="microphone">microphone</string>
 
     <!-- Recording Dialogs -->
-    <string name="stop_record_prompt">Are you sure you want to stop and save the recording?</string>
-    <string name="recording_yes_button">Yes</string>
-    <string name="recording_delete_button">Delete</string>
-    <string name="recording_cancel_button">Cancel</string>
     <string name="audio_instruction">Press button below to begin recording</string>
+    <string name="recording_cancel_button">Cancel</string>
+    <string name="recording_delete_button">Delete</string>
+    <string name="recording_yes_button">Yes</string>
+    <string name="stop_record_prompt">Are you sure you want to stop and save the recording?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="recording_yes_button">Yes</string>
     <string name="recording_delete_button">Delete</string>
     <string name="recording_cancel_button">Cancel</string>
+    <string name="audio_instruction">Press button below to begin recording</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,10 @@
     <string name="save_button">Save Critique</string>
     <string name="save_button_text">Save Critique</string>
     <string name="microphone">microphone</string>
+
+    <!-- Recording Dialogs -->
+    <string name="stop_record_prompt">Are you sure you want to stop and save the recording?</string>
+    <string name="recording_yes_button">Yes</string>
+    <string name="recording_delete_button">Delete</string>
+    <string name="recording_cancel_button">Cancel</string>
 </resources>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10265013/54066669-1323ec80-4202-11e9-924b-faac7f018a65.png)

![image](https://user-images.githubusercontent.com/10265013/54066677-1d45eb00-4202-11e9-9d6c-588bf6b0c66a.png)

![image](https://user-images.githubusercontent.com/10265013/54066679-246cf900-4202-11e9-8783-7e972a034bd7.png)

Implemented the recording button (Audio file field in form is still static, its a TODO).

The audio file saving workflow is as follows:
If the adjudication hasn't been saved, the audio file is saved to a local name which is different from the adjudication ID, as it's not available yet. If adjudication ID is available (i.e, it is in the "complete" tab in the performances screen), then the local audio file name will be the adjudication ID.

Recording an audio file before an adjudication is complete will not upload to Firebase Storage, as the associated Adjudication ID is not available yet. On first save, if an audio file has been recorded, it will send that audio file to Firebase. Subsequent recordings will then upload to the correct path in Firebase storage.
