### PR TITLE
Live update performances

### DIFF
--- a/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
@@ -201,7 +201,9 @@ class PerformanceActivity : AppCompatActivity() {
                 incompletePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
                 pagerAdapter.notifyDataSetChanged()
             }
-            if (firstRun) firstRun = false
+            if (firstRun) {
+                firstRun = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/PerformanceActivity.kt
@@ -63,107 +63,40 @@ class PerformanceActivity : AppCompatActivity() {
         val idFetcher = IDFetcher()
         idFetcher.registerCallback(database) { id ->
             tabletID = id
+            runOnUiThread {
+                pagerAdapter = PerformancePagerAdapter(
+                    adjudications,
+                    completePerformances,
+                    event,
+                    incompletePerformances,
+                    supportFragmentManager,
+                    tabletID
+                )
+                view_pager.adapter = pagerAdapter
+                view_pager.addOnPageChangeListener(
+                    TabLayout.TabLayoutOnPageChangeListener(tab_layout))
+                tab_layout.addOnTabSelectedListener(
+                    object : TabLayout.OnTabSelectedListener {
+                        override fun onTabReselected(tab: TabLayout.Tab) {}
+                        override fun onTabUnselected(tab: TabLayout.Tab) {}
+                        override fun onTabSelected(tab: TabLayout.Tab) {
+                            view_pager.currentItem = tab.position
+                        }
+                    })
+            }
             database
                 .collection("/$COLLECTION_EVENTS/${event.eventId}" +
                     "/$COLLECTION_PERFORMANCES")
-                .get()
-                .addOnSuccessListener {
-                    val countDownLatch = CountDownLatch(it.size())
-
-                    for (performanceDoc in it) {
-                        val academicLevel = performanceDoc.data[perfKeys.ARG_ACADEMIC_LEVEL]
-                        val choreographers = performanceDoc.data[perfKeys.ARG_CHOREOGRAPHERS]
-                        val competitionLevel = performanceDoc.data[perfKeys.ARG_COMPETITION_LEVEL]
-                        val danceEntry = performanceDoc.data[perfKeys.ARG_DANCE_ENTRY]
-                        val danceStyle = performanceDoc.data[perfKeys.ARG_DANCE_STYLE]
-                        val danceTitle = performanceDoc.data[perfKeys.ARG_DANCE_TITLE]
-                        val performers = performanceDoc.data[perfKeys.ARG_PERFORMERS]
-                        val school = performanceDoc.data[perfKeys.ARG_SCHOOL]
-                        val size = performanceDoc.data[perfKeys.ARG_SIZE]
-
-                        val newPerformance = Performance(
-                            performanceId = performanceDoc.id,
-                            academicLevel = FirestoreUtils.getVal(academicLevel, DEFAULT),
-                            choreographers = FirestoreUtils.getVal(choreographers, DEFAULT),
-                            competitionLevel = FirestoreUtils.getVal(competitionLevel, DEFAULT),
-                            danceEntry = FirestoreUtils.getVal(danceEntry, DEFAULT),
-                            danceStyle = FirestoreUtils.getVal(danceStyle, DEFAULT),
-                            danceTitle = FirestoreUtils.getVal(danceTitle, DEFAULT),
-                            performers = FirestoreUtils.getVal(performers, DEFAULT),
-                            school = FirestoreUtils.getVal(school, DEFAULT),
-                            size = FirestoreUtils.getVal(size, DEFAULT)
-                        )
-
-                        database
-                            .collection("/$COLLECTION_EVENTS/${event.eventId}" +
-                            "/$COLLECTION_PERFORMANCES/${performanceDoc.id}" +
-                            "/$COLLECTION_ADJUDICATIONS")
-                            .whereEqualTo(TAG_TABLET_ID, tabletID)
-                            .get()
-                            .addOnSuccessListener {
-                                if (it.size() == 0) {
-                                    incompletePerformances.add(newPerformance)
-                                } else {
-                                    completePerformances.add(newPerformance)
-                                    val adjDocData = it.documents[0].data
-                                    val artisticMark = adjDocData?.get(adjKeys.ARG_ARTISTIC_MARK)
-                                    val audioURL = adjDocData?.get(adjKeys.ARG_AUDIO_URL)
-                                    val choreoAward = adjDocData?.get(adjKeys.ARG_CHOREO_AWARD)
-                                    val cumulativeMark =
-                                        adjDocData?.get(adjKeys.ARG_CUMULATIVE_MARK)
-                                    val judgeName = adjDocData?.get(adjKeys.ARG_JUDGE_NAME)
-                                    val notes = adjDocData?.get(adjKeys.ARG_NOTES)
-                                    val specialAward = adjDocData?.get(adjKeys.ARG_SPECIAL_AWARD)
-                                    val technicalMark = adjDocData?.get(adjKeys.ARG_TECHNICAL_MARK)
-
-                                    adjudications[performanceDoc.id] = Adjudication(
-                                        adjudicationId = it.documents[0].id,
-                                        artisticMark = FirestoreUtils.getVal(artisticMark, -1),
-                                        audioURL = FirestoreUtils.getVal(audioURL, DEFAULT),
-                                        choreoAward = FirestoreUtils.getVal(choreoAward, false),
-                                        cumulativeMark = FirestoreUtils.getVal(cumulativeMark, -1),
-                                        judgeName = FirestoreUtils.getVal(judgeName, DEFAULT),
-                                        notes = FirestoreUtils.getVal(notes, DEFAULT),
-                                        specialAward = FirestoreUtils.getVal(specialAward, false),
-                                        technicalMark = FirestoreUtils.getVal(technicalMark, -1)
-                                    )
-                                }
-                                countDownLatch.countDown()
-                            }
-                            .addOnFailureListener {
-                                Log.e(TAG, "Failed to get adjudication for tabletID: $tabletID")
-                                countDownLatch.countDown()
-                            }
-                    }
-
-                    thread {
-                        countDownLatch.await()
-                        firstRun = false
-                        runOnUiThread {
-                            completePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
-                            incompletePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
-                            pagerAdapter = PerformancePagerAdapter(
-                                adjudications,
-                                completePerformances,
-                                event,
-                                incompletePerformances,
-                                supportFragmentManager,
-                                tabletID
-                            )
-                            view_pager.adapter = pagerAdapter
-                            view_pager.addOnPageChangeListener(
-                                TabLayout.TabLayoutOnPageChangeListener(tab_layout))
-                            tab_layout.addOnTabSelectedListener(
-                                object : TabLayout.OnTabSelectedListener {
-                                    override fun onTabReselected(tab: TabLayout.Tab) {}
-                                    override fun onTabUnselected(tab: TabLayout.Tab) {}
-                                    override fun onTabSelected(tab: TabLayout.Tab) {
-                                        view_pager.currentItem = tab.position
-                                    }
-                                })
+                    .addSnapshotListener { querySnapshot, error ->
+                        if (error != null) {
+                            Log.e(TAG, "Failed to listen to performance collection.", error)
+                            return@addSnapshotListener
                         }
+                        if (querySnapshot == null) {
+                            Log.e(TAG, "Null querySnapshot")
+                        }
+                        fetchData()
                     }
-                }
         }
     }
 
@@ -171,99 +104,103 @@ class PerformanceActivity : AppCompatActivity() {
         super.onResume()
 
         if (!firstRun) {
-            database
-                .collection("/$COLLECTION_EVENTS/${event.eventId}" +
-                    "/$COLLECTION_PERFORMANCES")
-                .get()
-                .addOnSuccessListener {
-                    completePerformances.clear()
-                    incompletePerformances.clear()
-                    adjudications.clear()
-
-                    val countDownLatch = CountDownLatch(it.size())
-
-                    for (performanceDoc in it) {
-                        val academicLevel = performanceDoc.data[perfKeys.ARG_ACADEMIC_LEVEL]
-                        val choreographers = performanceDoc.data[perfKeys.ARG_CHOREOGRAPHERS]
-                        val competitionLevel = performanceDoc.data[perfKeys.ARG_COMPETITION_LEVEL]
-                        val danceEntry = performanceDoc.data[perfKeys.ARG_DANCE_ENTRY]
-                        val danceStyle = performanceDoc.data[perfKeys.ARG_DANCE_STYLE]
-                        val danceTitle = performanceDoc.data[perfKeys.ARG_DANCE_TITLE]
-                        val performers = performanceDoc.data[perfKeys.ARG_PERFORMERS]
-                        val school = performanceDoc.data[perfKeys.ARG_SCHOOL]
-                        val size = performanceDoc.data[perfKeys.ARG_SIZE]
-
-                        val newPerformance = Performance(
-                            performanceId = performanceDoc.id,
-                            academicLevel = FirestoreUtils.getVal(academicLevel, DEFAULT),
-                            choreographers = FirestoreUtils.getVal(choreographers, DEFAULT),
-                            competitionLevel = FirestoreUtils.getVal(competitionLevel, DEFAULT),
-                            danceEntry = FirestoreUtils.getVal(danceEntry, DEFAULT),
-                            danceStyle = FirestoreUtils.getVal(danceStyle, DEFAULT),
-                            danceTitle = FirestoreUtils.getVal(danceTitle, DEFAULT),
-                            performers = FirestoreUtils.getVal(performers, DEFAULT),
-                            school = FirestoreUtils.getVal(school, DEFAULT),
-                            size = FirestoreUtils.getVal(size, DEFAULT)
-                        )
-
-                        database
-                            .collection("/$COLLECTION_EVENTS/${event.eventId}" +
-                            "/$COLLECTION_PERFORMANCES/${performanceDoc.id}" +
-                            "/$COLLECTION_ADJUDICATIONS")
-                            .whereEqualTo(TAG_TABLET_ID, tabletID)
-                            .get()
-                            .addOnSuccessListener {
-                                if (it.size() == 0) {
-                                    incompletePerformances.add(newPerformance)
-                                } else {
-                                    completePerformances.add(newPerformance)
-                                    val adjDocData = it.documents[0].data
-                                    val artisticMark = adjDocData?.get(adjKeys.ARG_ARTISTIC_MARK)
-                                    val audioURL = adjDocData?.get(adjKeys.ARG_AUDIO_URL)
-                                    val choreoAward = adjDocData?.get(adjKeys.ARG_CHOREO_AWARD)
-                                    val cumulativeMark =
-                                            adjDocData?.get(adjKeys.ARG_CUMULATIVE_MARK)
-                                    val judgeName = adjDocData?.get(adjKeys.ARG_JUDGE_NAME)
-                                    val notes = adjDocData?.get(adjKeys.ARG_NOTES)
-                                    val specialAward = adjDocData?.get(adjKeys.ARG_SPECIAL_AWARD)
-                                    val technicalMark = adjDocData?.get(adjKeys.ARG_TECHNICAL_MARK)
-
-                                    adjudications[performanceDoc.id] = Adjudication(
-                                        adjudicationId = it.documents[0].id,
-                                        artisticMark = FirestoreUtils.getVal(artisticMark, -1),
-                                        audioURL = FirestoreUtils.getVal(audioURL, DEFAULT),
-                                        choreoAward = FirestoreUtils.getVal(choreoAward, false),
-                                        cumulativeMark = FirestoreUtils.getVal(cumulativeMark, -1),
-                                        judgeName = FirestoreUtils.getVal(judgeName, DEFAULT),
-                                        notes = FirestoreUtils.getVal(notes, DEFAULT),
-                                        specialAward = FirestoreUtils.getVal(specialAward, false),
-                                        technicalMark = FirestoreUtils.getVal(technicalMark, -1)
-                                    )
-                                }
-                                countDownLatch.countDown()
-                            }
-                            .addOnFailureListener {
-                                Log.e(TAG, "Failed to get adjudication for tabletID: $tabletID")
-                                countDownLatch.countDown()
-                            }
-                    }
-
-                    thread {
-                        countDownLatch.await()
-                        runOnUiThread {
-                            completePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
-                            incompletePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
-                            pagerAdapter.notifyDataSetChanged()
-                        }
-                    }
-                }
+            fetchData()
         }
-
     }
 
     override fun onSupportNavigateUp(): Boolean {
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         onBackPressed()
         return true
+    }
+
+    private fun fetchData() {
+        database
+            .collection("/$COLLECTION_EVENTS/${event.eventId}" +
+                "/$COLLECTION_PERFORMANCES")
+            .get()
+            .addOnSuccessListener {
+                completePerformances.clear()
+                incompletePerformances.clear()
+                adjudications.clear()
+
+                val countDownLatch = CountDownLatch(it.size())
+
+                for (performanceDoc in it) {
+                    val academicLevel = performanceDoc.data[perfKeys.ARG_ACADEMIC_LEVEL]
+                    val choreographers = performanceDoc.data[perfKeys.ARG_CHOREOGRAPHERS]
+                    val competitionLevel = performanceDoc.data[perfKeys.ARG_COMPETITION_LEVEL]
+                    val danceEntry = performanceDoc.data[perfKeys.ARG_DANCE_ENTRY]
+                    val danceStyle = performanceDoc.data[perfKeys.ARG_DANCE_STYLE]
+                    val danceTitle = performanceDoc.data[perfKeys.ARG_DANCE_TITLE]
+                    val performers = performanceDoc.data[perfKeys.ARG_PERFORMERS]
+                    val school = performanceDoc.data[perfKeys.ARG_SCHOOL]
+                    val size = performanceDoc.data[perfKeys.ARG_SIZE]
+
+                    val newPerformance = Performance(
+                        performanceId = performanceDoc.id,
+                        academicLevel = FirestoreUtils.getVal(academicLevel, DEFAULT),
+                        choreographers = FirestoreUtils.getVal(choreographers, DEFAULT),
+                        competitionLevel = FirestoreUtils.getVal(competitionLevel, DEFAULT),
+                        danceEntry = FirestoreUtils.getVal(danceEntry, DEFAULT),
+                        danceStyle = FirestoreUtils.getVal(danceStyle, DEFAULT),
+                        danceTitle = FirestoreUtils.getVal(danceTitle, DEFAULT),
+                        performers = FirestoreUtils.getVal(performers, DEFAULT),
+                        school = FirestoreUtils.getVal(school, DEFAULT),
+                        size = FirestoreUtils.getVal(size, DEFAULT)
+                    )
+
+                    database
+                        .collection("/$COLLECTION_EVENTS/${event.eventId}" +
+                            "/$COLLECTION_PERFORMANCES/${performanceDoc.id}" +
+                            "/$COLLECTION_ADJUDICATIONS")
+                        .whereEqualTo(TAG_TABLET_ID, tabletID)
+                        .get()
+                        .addOnSuccessListener {
+                            if (it.size() == 0) {
+                                incompletePerformances.add(newPerformance)
+                            } else {
+                                completePerformances.add(newPerformance)
+                                val adjDocData = it.documents[0].data
+                                val artisticMark = adjDocData?.get(adjKeys.ARG_ARTISTIC_MARK)
+                                val audioURL = adjDocData?.get(adjKeys.ARG_AUDIO_URL)
+                                val choreoAward = adjDocData?.get(adjKeys.ARG_CHOREO_AWARD)
+                                val cumulativeMark =
+                                    adjDocData?.get(adjKeys.ARG_CUMULATIVE_MARK)
+                                val judgeName = adjDocData?.get(adjKeys.ARG_JUDGE_NAME)
+                                val notes = adjDocData?.get(adjKeys.ARG_NOTES)
+                                val specialAward = adjDocData?.get(adjKeys.ARG_SPECIAL_AWARD)
+                                val technicalMark = adjDocData?.get(adjKeys.ARG_TECHNICAL_MARK)
+
+                                adjudications[performanceDoc.id] = Adjudication(
+                                    adjudicationId = it.documents[0].id,
+                                    artisticMark = FirestoreUtils.getVal(artisticMark, -1),
+                                    audioURL = FirestoreUtils.getVal(audioURL, DEFAULT),
+                                    choreoAward = FirestoreUtils.getVal(choreoAward, false),
+                                    cumulativeMark = FirestoreUtils.getVal(cumulativeMark, -1),
+                                    judgeName = FirestoreUtils.getVal(judgeName, DEFAULT),
+                                    notes = FirestoreUtils.getVal(notes, DEFAULT),
+                                    specialAward = FirestoreUtils.getVal(specialAward, false),
+                                    technicalMark = FirestoreUtils.getVal(technicalMark, -1)
+                                )
+                            }
+                            countDownLatch.countDown()
+                        }
+                        .addOnFailureListener {
+                            Log.e(TAG, "Failed to get adjudication for tabletID: $tabletID")
+                            countDownLatch.countDown()
+                        }
+                }
+
+                thread {
+                    countDownLatch.await()
+                    runOnUiThread {
+                        completePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
+                        incompletePerformances.sortBy { perf -> perf.danceEntry.toDouble() }
+                        pagerAdapter.notifyDataSetChanged()
+                    }
+                    if (firstRun) firstRun = false
+                }
+            }
     }
 }

--- a/app/src/main/java/com/uwblueprint/dancefest/PerformanceFragment.kt
+++ b/app/src/main/java/com/uwblueprint/dancefest/PerformanceFragment.kt
@@ -24,6 +24,7 @@ class PerformanceFragment : Fragment(), PerformanceItemListener {
     private var isCompletePerformances: Boolean = false
     private var tabletID: Long = -1
 
+    private lateinit var recyclerView: RecyclerView
     private var savedRecyclerState: Parcelable? = null
     private lateinit var viewAdapter: RecyclerView.Adapter<*>
     private lateinit var viewManager: RecyclerView.LayoutManager
@@ -39,6 +40,7 @@ class PerformanceFragment : Fragment(), PerformanceItemListener {
         savedInstanceState: Bundle?
     ): View {
         val rootView: View = inflater.inflate(R.layout.fragment_performance, container, false)
+        recyclerView = rootView.findViewById(R.id.list_performances)
         arguments?.takeIf { it.containsKey(PerformanceActivity.TAG_ADJUDICATIONS) }?.apply {
             val newAdjudications = getSerializable(PerformanceActivity.TAG_ADJUDICATIONS)
             adjudications = if (newAdjudications is HashMap<*, *>) {
@@ -85,7 +87,7 @@ class PerformanceFragment : Fragment(), PerformanceItemListener {
 
         viewManager = LinearLayoutManager(context)
         viewAdapter = PerformancesAdapter(adjudications, this, performances)
-        list_performances.apply {
+        recyclerView.apply {
             layoutManager = viewManager
             adapter = viewAdapter
         }
@@ -98,11 +100,9 @@ class PerformanceFragment : Fragment(), PerformanceItemListener {
 
     fun updateData(adjudications: HashMap<*, *>, performances: ArrayList<Performance>) {
         viewAdapter = PerformancesAdapter(adjudications, this, performances)
-        list_performances.apply {
-            adapter = viewAdapter
-        }
+        recyclerView.adapter = viewAdapter
         if (savedRecyclerState != null) {
-            list_performances.layoutManager?.onRestoreInstanceState(savedRecyclerState)
+            recyclerView.layoutManager?.onRestoreInstanceState(savedRecyclerState)
         }
     }
 


### PR DESCRIPTION
Fixed by adding a general fetchData function in PerformanceActivity. fetchData is called on snapshot update or when returning back to PerformanceActivity.

Just making sure, I didn't think the update needed to happen when an adjudication updated as well, since adjudications are tablet specific.